### PR TITLE
KAN-1: Create DynamoDB table terraform configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,36 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Terraform
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+*tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.99.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:xgPyZArCfKVMy8sThzhb0IernbFy0fJGm897ztejZAQ=",
+    "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
+    "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",
+    "zh:2035977ed418dcb18290785c1eeb79b7133b39f718c470346e043ac48887ffc7",
+    "zh:67e3ca1bf7061900f81cf958d5c771a2fd6048c2b185bec7b27978349b173a90",
+    "zh:87fadbe5de7347ede72ad879ff8d8d9334103cd9aa4a321bb086bfac91654944",
+    "zh:901d170c457c2bff244a2282d9de595bdb3ebecc33a2034c5ce8aafbcff66db9",
+    "zh:92c07d6cf530679565b87934f9f98604652d787968cce6a3d24c148479b7e34b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7d4803b4c5ff17f029f8b270c91480442ece27cec7922c38548bcfea2ac2d26",
+    "zh:afda848da7993a07d29018ec25ab6feda652e01d4b22721da570ce4fcc005292",
+    "zh:baaf16c98b81bad070e0908f057a97108ecd6e8c9f754d7a79b18df4c8453279",
+    "zh:c3dd496c5014427599d6b6b1c14c7ebb09a15df78918ae0be935e7bfa83b894c",
+    "zh:e2b84c1d40b3f2c4b1d74bf170b9e932983b61bac0e6dab2e36f5057ddcc997f",
+    "zh:e49c92cb29c53b4573ed4d9c946486e6bcfc1b63f1aee0c79cc7626f3d9add03",
+    "zh:efae8e339c4b13f546e0f96c42eb95bf8347de22e941594849b12688574bf380",
+  ]
+}

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -1,0 +1,66 @@
+# TFLint configuration for Parts Service Terraform code
+
+config {
+  # Disable terraform provider plugin by default
+  disabled_by_default = false
+  
+  # Enable specific rule sets
+  plugin_dir = "~/.tflint.d/plugins"
+}
+
+# AWS plugin configuration
+plugin "aws" {
+  enabled = true
+  version = "0.30.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+# Enable Terraform core rules
+plugin "terraform" {
+  enabled = true
+  version = "0.5.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+}
+
+# Terraform core rules
+rule "terraform_deprecated_interpolation" {
+  enabled = true
+}
+
+rule "terraform_deprecated_index" {
+  enabled = true
+}
+
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = true
+}
+
+rule "terraform_naming_convention" {
+  enabled = true
+  format  = "snake_case"
+}
+
+rule "terraform_standard_module_structure" {
+  enabled = true
+}
+
+# AWS resource rules
+rule "aws_resource_missing_tags" {
+  enabled = false  # Disabled as we use default_tags in provider
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,175 @@
+# Terraform Infrastructure for Parts Service
+
+This directory contains Terraform configuration files for provisioning AWS infrastructure for the Parts Service application.
+
+## Overview
+
+This Terraform configuration creates a DynamoDB table specifically designed for the Parts Service application with the following specifications:
+
+- **Table Name**: `unt-part-svc`
+- **Primary Key**: `PK` (String)
+- **Sort Key**: `SK` (String)
+- **Streams**: Enabled with `NEW_AND_OLD_IMAGES` view type
+- **Billing Mode**: Pay-per-request (on-demand)
+- **Encryption**: Server-side encryption enabled
+- **Point-in-time Recovery**: Enabled by default
+
+## File Structure
+
+```
+terraform/
+├── README.md           # This documentation file
+├── versions.tf         # Terraform and provider version constraints
+├── providers.tf        # AWS provider configuration
+├── variables.tf        # Input variables
+├── main.tf            # Main DynamoDB table resource
+└── outputs.tf         # Output values
+```
+
+## Prerequisites
+
+1. **Terraform**: Version >= 1.0
+2. **AWS CLI**: Configured with appropriate credentials
+3. **AWS Provider**: Version ~> 5.0
+
+## Usage
+
+### Initialize Terraform
+
+```bash
+cd terraform
+terraform init
+```
+
+### Plan the Infrastructure
+
+```bash
+terraform plan
+```
+
+### Apply the Infrastructure
+
+```bash
+terraform apply
+```
+
+### Destroy the Infrastructure
+
+```bash
+terraform destroy
+```
+
+## Configuration Variables
+
+| Variable | Description | Type | Default | Required |
+|----------|-------------|------|---------|----------|
+| `aws_region` | AWS region for resources | string | `us-east-1` | No |
+| `environment` | Environment name (dev, staging, prod) | string | `dev` | No |
+| `project_name` | Name of the project | string | `parts-service` | No |
+| `owner` | Owner of the resources | string | `parts-team` | No |
+| `dynamodb_table_name` | Name of the DynamoDB table | string | `unt-part-svc` | No |
+| `primary_key_name` | Name of the primary key | string | `PK` | No |
+| `sort_key_name` | Name of the sort key | string | `SK` | No |
+| `billing_mode` | Billing mode (PAY_PER_REQUEST or PROVISIONED) | string | `PAY_PER_REQUEST` | No |
+| `stream_enabled` | Enable DynamoDB streams | bool | `true` | No |
+| `stream_view_type` | Stream view type | string | `NEW_AND_OLD_IMAGES` | No |
+| `deletion_protection_enabled` | Enable deletion protection | bool | `false` | No |
+| `point_in_time_recovery_enabled` | Enable point-in-time recovery | bool | `true` | No |
+
+## Customization
+
+To customize the configuration for different environments, you can:
+
+1. **Create environment-specific `.tfvars` files**:
+   ```bash
+   # dev.tfvars
+   environment = "dev"
+   aws_region = "us-east-1"
+   deletion_protection_enabled = false
+   
+   # prod.tfvars
+   environment = "prod"
+   aws_region = "us-west-2"
+   deletion_protection_enabled = true
+   ```
+
+2. **Use the files with terraform commands**:
+   ```bash
+   terraform plan -var-file="dev.tfvars"
+   terraform apply -var-file="prod.tfvars"
+   ```
+
+## Outputs
+
+This configuration provides the following outputs:
+
+- `dynamodb_table_name`: Name of the created DynamoDB table
+- `dynamodb_table_id`: ID of the DynamoDB table
+- `dynamodb_table_arn`: ARN of the DynamoDB table
+- `dynamodb_table_stream_arn`: ARN of the DynamoDB table stream
+- `dynamodb_table_stream_label`: Timestamp when the stream was enabled
+- `dynamodb_table_hash_key`: Hash key (primary key) name
+- `dynamodb_table_range_key`: Range key (sort key) name
+- `dynamodb_table_billing_mode`: Billing mode of the table
+- `dynamodb_table_stream_enabled`: Whether streams are enabled
+- `dynamodb_table_stream_view_type`: Stream view type configuration
+
+## Security Features
+
+- **Server-side encryption**: Enabled by default using AWS managed keys
+- **Point-in-time recovery**: Enabled for data protection
+- **Default tags**: Applied for resource management and cost tracking
+- **Input validation**: Variables include validation rules where appropriate
+
+## Best Practices Implemented
+
+- ✅ Consistent naming conventions using snake_case
+- ✅ Comprehensive variable documentation with types and validation
+- ✅ Explicit provider version constraints
+- ✅ Descriptive resource and variable names
+- ✅ Comprehensive tagging strategy
+- ✅ Security best practices (encryption, recovery)
+- ✅ Modular file organization
+- ✅ Input validation for critical variables
+
+## Troubleshooting
+
+### Common Issues
+
+1. **AWS Credentials**: Ensure your AWS credentials are properly configured
+   ```bash
+   aws configure list
+   ```
+
+2. **Permissions**: Verify you have the necessary IAM permissions for DynamoDB operations
+
+3. **Region**: Ensure the specified AWS region supports DynamoDB (all regions do)
+
+### Validation Commands
+
+Before applying, run these commands to ensure code quality:
+
+```bash
+# Format the code
+terraform fmt
+
+# Validate the configuration
+terraform validate
+
+# Run tflint (if installed)
+tflint
+```
+
+## Related Documentation
+
+- [AWS DynamoDB Terraform Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table)
+- [DynamoDB Streams Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html)
+- [Terraform Best Practices](https://www.terraform.io/docs/cloud/guides/recommended-practices/index.html)
+
+## Support
+
+For issues related to this infrastructure configuration, please:
+
+1. Check the troubleshooting section above
+2. Refer to the AWS DynamoDB documentation
+3. Create an issue in the project repository with relevant error messages and steps to reproduce

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,35 @@
+# DynamoDB table for Parts Service
+resource "aws_dynamodb_table" "parts_table" {
+  name             = var.dynamodb_table_name
+  billing_mode     = var.billing_mode
+  hash_key         = var.primary_key_name
+  range_key        = var.sort_key_name
+  stream_enabled   = var.stream_enabled
+  stream_view_type = var.stream_enabled ? var.stream_view_type : null
+
+  deletion_protection_enabled = var.deletion_protection_enabled
+
+  attribute {
+    name = var.primary_key_name
+    type = "S"
+  }
+
+  attribute {
+    name = var.sort_key_name
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = var.point_in_time_recovery_enabled
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  tags = {
+    Name        = var.dynamodb_table_name
+    Description = "DynamoDB table for Parts Service application"
+    Component   = "database"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,51 @@
+# Outputs for DynamoDB table information
+
+output "dynamodb_table_name" {
+  description = "Name of the DynamoDB table"
+  value       = aws_dynamodb_table.parts_table.name
+}
+
+output "dynamodb_table_id" {
+  description = "ID of the DynamoDB table"
+  value       = aws_dynamodb_table.parts_table.id
+}
+
+output "dynamodb_table_arn" {
+  description = "ARN of the DynamoDB table"
+  value       = aws_dynamodb_table.parts_table.arn
+}
+
+output "dynamodb_table_stream_arn" {
+  description = "ARN of the DynamoDB table stream"
+  value       = aws_dynamodb_table.parts_table.stream_arn
+}
+
+output "dynamodb_table_stream_label" {
+  description = "Timestamp of when the stream was enabled"
+  value       = aws_dynamodb_table.parts_table.stream_label
+}
+
+output "dynamodb_table_hash_key" {
+  description = "Hash key (primary key) of the DynamoDB table"
+  value       = aws_dynamodb_table.parts_table.hash_key
+}
+
+output "dynamodb_table_range_key" {
+  description = "Range key (sort key) of the DynamoDB table"
+  value       = aws_dynamodb_table.parts_table.range_key
+}
+
+output "dynamodb_table_billing_mode" {
+  description = "Billing mode of the DynamoDB table"
+  value       = aws_dynamodb_table.parts_table.billing_mode
+}
+
+output "dynamodb_table_stream_enabled" {
+  description = "Whether streams are enabled for the DynamoDB table"
+  value       = aws_dynamodb_table.parts_table.stream_enabled
+}
+
+output "dynamodb_table_stream_view_type" {
+  description = "Stream view type of the DynamoDB table"
+  value       = aws_dynamodb_table.parts_table.stream_view_type
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,13 @@
+# AWS Provider Configuration
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = var.project_name
+      ManagedBy   = "terraform"
+      Owner       = var.owner
+    }
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,32 @@
+# Example Terraform variables file
+# Copy this file to terraform.tfvars and customize for your environment
+
+# AWS Configuration
+aws_region = "us-east-1"
+
+# Environment Configuration
+environment  = "dev"
+project_name = "parts-service"
+owner        = "parts-team"
+
+# DynamoDB Table Configuration
+dynamodb_table_name = "unt-part-svc"
+primary_key_name    = "PK"
+sort_key_name       = "SK"
+
+# Billing and Performance
+billing_mode = "PAY_PER_REQUEST"
+
+# Streams Configuration
+stream_enabled   = true
+stream_view_type = "NEW_AND_OLD_IMAGES"
+
+# Data Protection
+deletion_protection_enabled      = false
+point_in_time_recovery_enabled   = true
+
+# Example for production environment:
+# environment = "prod"
+# aws_region = "us-west-2"
+# deletion_protection_enabled = true
+# billing_mode = "PROVISIONED"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,98 @@
+# Variables for DynamoDB table configuration
+
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "project_name" {
+  description = "Name of the project"
+  type        = string
+  default     = "parts-service"
+}
+
+variable "owner" {
+  description = "Owner of the resources"
+  type        = string
+  default     = "parts-team"
+}
+
+variable "dynamodb_table_name" {
+  description = "Name of the DynamoDB table for parts service"
+  type        = string
+  default     = "unt-part-svc"
+
+  validation {
+    condition     = length(var.dynamodb_table_name) >= 3 && length(var.dynamodb_table_name) <= 255
+    error_message = "DynamoDB table name must be between 3 and 255 characters."
+  }
+}
+
+variable "primary_key_name" {
+  description = "Name of the primary key for the DynamoDB table"
+  type        = string
+  default     = "PK"
+}
+
+variable "sort_key_name" {
+  description = "Name of the sort key for the DynamoDB table"
+  type        = string
+  default     = "SK"
+}
+
+variable "billing_mode" {
+  description = "Billing mode for the DynamoDB table"
+  type        = string
+  default     = "PAY_PER_REQUEST"
+
+  validation {
+    condition     = contains(["PAY_PER_REQUEST", "PROVISIONED"], var.billing_mode)
+    error_message = "Billing mode must be either PAY_PER_REQUEST or PROVISIONED."
+  }
+}
+
+variable "stream_enabled" {
+  description = "Enable DynamoDB streams for the table"
+  type        = bool
+  default     = true
+}
+
+variable "stream_view_type" {
+  description = "Stream view type when streams are enabled"
+  type        = string
+  default     = "NEW_AND_OLD_IMAGES"
+
+  validation {
+    condition = contains([
+      "KEYS_ONLY",
+      "NEW_IMAGE",
+      "OLD_IMAGE",
+      "NEW_AND_OLD_IMAGES"
+    ], var.stream_view_type)
+    error_message = "Stream view type must be one of: KEYS_ONLY, NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES."
+  }
+}
+
+variable "deletion_protection_enabled" {
+  description = "Enable deletion protection for the DynamoDB table"
+  type        = bool
+  default     = false
+}
+
+variable "point_in_time_recovery_enabled" {
+  description = "Enable point-in-time recovery for the DynamoDB table"
+  type        = bool
+  default     = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## 📋 Summary

This PR implements the DynamoDB table infrastructure for the Parts Service as specified in Jira ticket KAN-1.

## 🎯 Requirements Implemented

- ✅ **DynamoDB table name**: `unt-part-svc`
- ✅ **Primary key**: `PK` (String type)
- ✅ **Sort key**: `SK` (String type)
- ✅ **Streams enabled**: Yes, with `NEW_AND_OLD_IMAGES` view type
- ✅ **Terraform directory**: Created in `/terraform` off project root
- ✅ **Code quality**: All code passes `tflint`, `terraform validate`, and `terraform fmt`

## 🏗️ Changes Made

### New Files Created:
- `terraform/main.tf` - DynamoDB table resource definition
- `terraform/variables.tf` - Comprehensive variable definitions with validation
- `terraform/outputs.tf` - Output values for table information
- `terraform/providers.tf` - AWS provider configuration with default tags
- `terraform/versions.tf` - Terraform and provider version constraints
- `terraform/README.md` - Comprehensive documentation
- `terraform/terraform.tfvars.example` - Example configuration file
- `terraform/.tflint.hcl` - Linting configuration

### Modified Files:
- `.gitignore` - Added Terraform-specific entries

## 🔧 Additional Features

- **Security**: Server-side encryption enabled by default
- **Data Protection**: Point-in-time recovery enabled
- **Resource Management**: Comprehensive tagging strategy
- **Validation**: Input validation for all critical variables
- **Documentation**: Extensive README with usage examples
- **Best Practices**: Follows all Terraform best practices

## 🧪 Validation Results

All validation checks pass:
```bash
✅ terraform fmt -check    # Code properly formatted
✅ terraform validate     # Configuration valid
✅ tflint                 # Linting passed
```

## 📖 Usage

To deploy the infrastructure:
```bash
cd terraform
terraform init
terraform plan
terraform apply
```

## 🔗 Related Issues

Resolves: KAN-1

## 📝 Notes

- The implementation follows all Terraform best practices from the provided rules
- Code is production-ready with comprehensive documentation
- All variables include proper validation and documentation
- Security features are enabled by default